### PR TITLE
Bump dependencies versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ruby-lce.gemspec
 gemspec
-
-gem 'awesome_print'

--- a/lce.gemspec
+++ b/lce.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday_middleware", "~> 0.12.2"
   spec.add_dependency "faraday_middleware-parse_oj", "~> 0.3.2"
   spec.add_dependency "hashie", "~> 3.6.0"  
+  spec.add_dependency 'awesome_print', '~> 1.8.0'
 end

--- a/lce.gemspec
+++ b/lce.gemspec
@@ -22,9 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webmock', '~> 1.18.0'
 
-  spec.add_dependency "faraday", "~> 0.9"
-  spec.add_dependency "faraday_middleware", "~> 0.9.1"
-  spec.add_dependency "faraday_middleware-parse_oj", "~> 0.3.0"  
-  spec.add_dependency "hashie", "~> 3.2.0"  
-
+  spec.add_dependency "faraday", "~> 0.15.2"
+  spec.add_dependency "faraday_middleware", "~> 0.12.2"
+  spec.add_dependency "faraday_middleware-parse_oj", "~> 0.3.2"
+  spec.add_dependency "hashie", "~> 3.6.0"  
 end

--- a/lib/lce/version.rb
+++ b/lib/lce/version.rb
@@ -1,4 +1,4 @@
 module Lce
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end
 


### PR DESCRIPTION
I lately used your gem in one of my project, but had to bump the dependencies versions.
Indeed, Bundler couldn't resolve dependencies without changing the `gemspec`.

Maybe you could be interested in these small changes.